### PR TITLE
Add PyPI release workflow (milestone 8)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
+
+      - name: Build
+        run: uv build
+
+      - uses: actions/upload-artifact@v7.0.1
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/scgist
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.14.2


### PR DESCRIPTION
## Milestone 8: release readiness

Adds `.github/workflows/release.yml`: builds sdist/wheel with `uv build` and
publishes to PyPI via trusted publishing (OIDC) when a GitHub Release is
published. No API tokens/secrets involved — PyPI verifies the workflow's
identity against a registered trusted publisher and self-issues a one-shot
upload credential.

### Verification

- Dry-run build: `uv build` → wheel contains only `scgist/` package files,
  no benchmarks/data/notebooks leaked in.
- Installed the built wheel into a throwaway venv; `from scgist import
  scGIST` imports cleanly.
- `ruff check .`, `mypy src`, `pytest` all pass.
- PyPI pending trusted publisher registered for `scgist`, pointing at this
  repo, `release.yml`, and the `pypi` environment (one-time manual setup,
  done outside this PR).

### Deferred (not part of this PR)

- Actually tagging `v2.0.0` and cutting the GitHub Release — done after this
  merges to `main`.
- Bumping `CITATION.cff` to the new version — a release-time step alongside
  the tag, not this PR.
