### PR TITLE
Prepare docs for v2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-09-02
+
 ### Changed
 
 - **Breaking:** renamed the importable package from `scGIST` to lowercase `scgist`
@@ -29,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A pytest suite covering `FeatureRegularizer`, `OneToOneLayer`,
   `get_priority_score_list`, `scGIST`, and `test_classifier`.
 - GitHub Actions CI workflow: lint, type-check, and test on Python 3.10–3.13.
+- Published to PyPI as `scgist`, with a GitHub Actions release workflow that
+  publishes via PyPI trusted publishing (OIDC) on each GitHub Release.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,19 @@ scGIST is a deep neural network that designs sc-ST gene panel through constraine
 
 ## Installation
 
-scGIST isn't published on PyPI yet — install it from source with [uv](https://docs.astral.sh/uv/):
+```bash
+pip install scgist
+```
+
+Or with [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv add scgist
+```
+
+Requires Python 3.10–3.13.
+
+### From source
 
 ```bash
 git clone https://github.com/yafi38/scGIST.git
@@ -15,7 +27,7 @@ uv sync
 ```
 
 This installs scGIST into a local `.venv`; run scripts with `uv run python ...` or activate the
-virtualenv directly. Requires Python 3.10–3.13.
+virtualenv directly.
 
 ## Usage
 


### PR DESCRIPTION
Closes out CHANGELOG's [Unreleased] section as [2.0.0], and restores `pip install`/`uv add` as the primary README install path now that `scgist` is being published to PyPI (source install kept as a secondary option for dev work).

No code changes.