### PR TITLE
Drop email from author metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-09-03
+
+### Fixed
+
+- Dropped the email from `pyproject.toml`'s author metadata. Mixing an
+  author with an email and one without collapses into PyPI's separate
+  `Author`/`Author-email` core-metadata fields, which have no per-person
+  structure — the result rendered as if the email belonged to the
+  *other* author on the PyPI project page.
+
 ## [2.0.0] - 2026-09-02
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10,<3.14"
 authors = [
-    { name = "Mashrur Ahmed Yafi", email = "yafi2475@gmail.com" },
+    { name = "Mashrur Ahmed Yafi" },
     { name = "Md. Hasibul Husain Hisham" },
 ]
 classifiers = [


### PR DESCRIPTION
Fixes the PyPI project page rendering the email next to the wrong author's name.

PEP 621's `authors` list collapses into two flat core-metadata fields on build: any author with an email lands in `Author-email`, any author without lands in a separate `Author` field — there's no per-person structure linking a name to its email across the two. With one author having an email and one not, PyPI's page ends up displaying the sole email next to whichever name is in the `Author` field, which reads as if it belongs to that person.

Dropping the email from both entries avoids the false association; neither author shows a mailto link.

No code changes.